### PR TITLE
Better connect statements

### DIFF
--- a/src/Comic.cpp
+++ b/src/Comic.cpp
@@ -47,7 +47,7 @@ Comic::Comic(QString id, QObject *parent) :
     m_timeoutTimer = new QTimer(this);
     m_timeoutTimer->setInterval(_timeout);
     m_timeoutTimer->setSingleShot(true);
-    connect(m_timeoutTimer, SIGNAL(timeout()), this, SLOT(timeout()));
+    connect(m_timeoutTimer, &QTimer::timeout, this, &Comic::timeout);
 }
 
 Comic::~Comic()
@@ -130,9 +130,9 @@ void Comic::fetchStripSource(QUrl stripSrcUrl)
     setFetching(true);
     setFetchingProgress(0);
 
-    connect(m_currentReply, SIGNAL(finished()), this, SLOT(onFetchStripSourceFinished()));
-    connect(m_currentReply, SIGNAL(downloadProgress(qint64,qint64)), this, SIGNAL(downloadProgress(qint64,qint64)));
-    connect(m_currentReply, SIGNAL(downloadProgress(qint64,qint64)), this, SLOT(updateFetchingProgress(qint64,qint64)));
+    connect(m_currentReply, &QNetworkReply::finished, this, &Comic::onFetchStripSourceFinished);
+    connect(m_currentReply, &QNetworkReply::downloadProgress, this, &Comic::downloadProgress);
+    connect(m_currentReply, &QNetworkReply::downloadProgress, this, &Comic::updateFetchingProgress);
 }
 
 void Comic::abortFetching()
@@ -237,9 +237,9 @@ void Comic::fetchStripImage(QUrl stripImageUrl)
 
     m_timeoutTimer->start();
 
-    connect(m_currentReply, SIGNAL(finished()), this, SLOT(onFetchStripImageFinished()));
-    connect(m_currentReply, SIGNAL(downloadProgress(qint64,qint64)), this, SIGNAL(downloadProgress(qint64,qint64)));
-    connect(m_currentReply, SIGNAL(downloadProgress(qint64,qint64)), this, SLOT(updateFetchingProgress(qint64,qint64)));
+    connect(m_currentReply, &QNetworkReply::finished, this, &Comic::onFetchStripImageFinished);
+    connect(m_currentReply, &QNetworkReply::downloadProgress, this, &Comic::downloadProgress);
+    connect(m_currentReply, &QNetworkReply::downloadProgress, this, &Comic::updateFetchingProgress);
 }
 
 void Comic::onFetchStripImageFinished()

--- a/src/ComicProxy.cpp
+++ b/src/ComicProxy.cpp
@@ -16,17 +16,17 @@ ComicProxy::ComicProxy(QObject *parent) :
     QObject(parent),
     m_comic(NULL)
 {
-    connect(this, SIGNAL(idChanged()), SIGNAL(nameChanged()));
-    connect(this, SIGNAL(idChanged()), SIGNAL(authorsChanged()));
-    connect(this, SIGNAL(idChanged()), SIGNAL(homepageChanged()));
-    connect(this, SIGNAL(idChanged()), SIGNAL(languageChanged()));
-    connect(this, SIGNAL(idChanged()), SIGNAL(stripImagePathChanged()));
-    connect(this, SIGNAL(idChanged()), SIGNAL(stripImageUrlChanged()));
-    connect(this, SIGNAL(idChanged()), SIGNAL(coverPathChanged()));
-    connect(this, SIGNAL(idChanged()), SIGNAL(examplePathChanged()));
-    connect(this, SIGNAL(idChanged()), SIGNAL(errorChanged()));
-    connect(this, SIGNAL(idChanged()), SIGNAL(animatedChanged()));
-    connect(this, SIGNAL(idChanged()), SIGNAL(stripImageDownloadedChanged()));
+    connect(this, &ComicProxy::idChanged, &ComicProxy::nameChanged);
+    connect(this, &ComicProxy::idChanged, &ComicProxy::authorsChanged);
+    connect(this, &ComicProxy::idChanged, &ComicProxy::homepageChanged);
+    connect(this, &ComicProxy::idChanged, &ComicProxy::languageChanged);
+    connect(this, &ComicProxy::idChanged, &ComicProxy::stripImagePathChanged);
+    connect(this, &ComicProxy::idChanged, &ComicProxy::stripImageUrlChanged);
+    connect(this, &ComicProxy::idChanged, &ComicProxy::coverPathChanged);
+    connect(this, &ComicProxy::idChanged, &ComicProxy::examplePathChanged);
+    connect(this, &ComicProxy::idChanged, &ComicProxy::errorChanged);
+    connect(this, &ComicProxy::idChanged, &ComicProxy::animatedChanged);
+    connect(this, &ComicProxy::idChanged, &ComicProxy::stripImageDownloadedChanged);
 }
 
 QString ComicProxy::id() const
@@ -101,17 +101,17 @@ void ComicProxy::setComic(Comic *comic)
 
     m_comic = comic;
 
-    connect(m_comic, SIGNAL(fetchStarted()), this, SIGNAL(fetchStarted()));
-    connect(m_comic, SIGNAL(fetchSucceeded()), this, SIGNAL(fetchSucceeded()));
-    connect(m_comic, SIGNAL(networkError()), this, SIGNAL(networkError()));
-    connect(m_comic, SIGNAL(parsingError()), this, SIGNAL(parsingError()));
-    connect(m_comic, SIGNAL(savingError()), this, SIGNAL(savingError()));
-    connect(m_comic, SIGNAL(downloadProgress(qint64,qint64)), this, SIGNAL(downloadProgress(qint64,qint64)));
-    connect(m_comic, SIGNAL(fetchSucceeded()), this, SIGNAL(stripImagePathChanged()));
-    connect(m_comic, SIGNAL(fetchSucceeded()), this, SIGNAL(stripImageUrlChanged()));
-    connect(m_comic, SIGNAL(fetchSucceeded()), this, SIGNAL(animatedChanged()));
-    connect(m_comic, SIGNAL(fetchSucceeded()), this, SIGNAL(stripImageDownloadedChanged()));
-    connect(m_comic, SIGNAL(errorChanged(Comic*)), this, SIGNAL(errorChanged()));
+    connect(m_comic, &Comic::fetchStarted, this, &ComicProxy::fetchStarted);
+    connect(m_comic, &Comic::fetchSucceeded, this, &ComicProxy::fetchSucceeded);
+    connect(m_comic, &Comic::networkError, this, &ComicProxy::networkError);
+    connect(m_comic, &Comic::parsingError, this, &ComicProxy::parsingError);
+    connect(m_comic, &Comic::savingError, this, &ComicProxy::savingError);
+    connect(m_comic, &Comic::downloadProgress, this, &ComicProxy::downloadProgress);
+    connect(m_comic, &Comic::fetchSucceeded, this, &ComicProxy::stripImagePathChanged);
+    connect(m_comic, &Comic::fetchSucceeded, this, &ComicProxy::stripImageUrlChanged);
+    connect(m_comic, &Comic::fetchSucceeded, this, &ComicProxy::animatedChanged);
+    connect(m_comic, &Comic::fetchSucceeded, this, &ComicProxy::stripImageDownloadedChanged);
+    connect(m_comic, &Comic::errorChanged, this, &ComicProxy::errorChanged);
 
     emit idChanged();
     emit comicChanged();

--- a/src/ComicProxy.cpp
+++ b/src/ComicProxy.cpp
@@ -99,6 +99,20 @@ void ComicProxy::setComic(Comic *comic)
     if (comic == NULL || m_comic == comic)
         return;
 
+    if (m_comic != NULL) {
+        disconnect(m_comic, &Comic::fetchStarted, this, &ComicProxy::fetchStarted);
+        disconnect(m_comic, &Comic::fetchSucceeded, this, &ComicProxy::fetchSucceeded);
+        disconnect(m_comic, &Comic::networkError, this, &ComicProxy::networkError);
+        disconnect(m_comic, &Comic::parsingError, this, &ComicProxy::parsingError);
+        disconnect(m_comic, &Comic::savingError, this, &ComicProxy::savingError);
+        disconnect(m_comic, &Comic::downloadProgress, this, &ComicProxy::downloadProgress);
+        disconnect(m_comic, &Comic::fetchSucceeded, this, &ComicProxy::stripImagePathChanged);
+        disconnect(m_comic, &Comic::fetchSucceeded, this, &ComicProxy::stripImageUrlChanged);
+        disconnect(m_comic, &Comic::fetchSucceeded, this, &ComicProxy::animatedChanged);
+        disconnect(m_comic, &Comic::fetchSucceeded, this, &ComicProxy::stripImageDownloadedChanged);
+        disconnect(m_comic, &Comic::errorChanged, this, &ComicProxy::errorChanged);
+    }
+
     m_comic = comic;
 
     connect(m_comic, &Comic::fetchStarted, this, &ComicProxy::fetchStarted);

--- a/src/ComicsModel.cpp
+++ b/src/ComicsModel.cpp
@@ -25,9 +25,9 @@ ComicsModel::ComicsModel(QObject *parent) :
     factory    = ComicFactory::instance();
     settings   = Settings::instance();
 
-    connect(this, SIGNAL(modelReset()), this, SLOT(emitCountsChanged()));
-    connect(this, SIGNAL(rowsInserted(QModelIndex,int,int)), this, SLOT(emitCountsChanged()));
-    connect(this, SIGNAL(rowsRemoved(QModelIndex,int,int)), this, SLOT(emitCountsChanged()));
+    connect(this, &ComicsModel::modelReset, this, &ComicsModel::emitCountsChanged);
+    connect(this, &ComicsModel::rowsInserted, this, &ComicsModel::emitCountsChanged);
+    connect(this, &ComicsModel::rowsRemoved, this, &ComicsModel::emitCountsChanged);
 }
 
 ComicsModel::~ComicsModel()
@@ -140,11 +140,11 @@ void ComicsModel::loadAll()
 
         comic->load();
 
-        connect(comic, SIGNAL(favoriteChanged(Comic*)), this, SLOT(emitFavoriteChanged(Comic*)));
-        connect(comic, SIGNAL(newStripChanged(Comic*)), this, SLOT(emitNewStripChanged(Comic*)));
-        connect(comic, SIGNAL(errorChanged(Comic*)), this, SLOT(emitErrorChanged(Comic*)));
-        connect(comic, SIGNAL(fetchingChanged(Comic*)), this, SLOT(emitFetchingChanged(Comic*)));
-        connect(comic, SIGNAL(fetchingProgressChanged(Comic*)), this, SLOT(emitFetchingProgressChanged(Comic*)));
+        connect(comic, &Comic::favoriteChanged, this, &ComicsModel::emitFavoriteChanged);
+        connect(comic, &Comic::newStripChanged, this, &ComicsModel::emitNewStripChanged);
+        connect(comic, &Comic::errorChanged, this, &ComicsModel::emitErrorChanged);
+        connect(comic, &Comic::fetchingChanged, this, &ComicsModel::emitFetchingChanged);
+        connect(comic, &Comic::fetchingProgressChanged, this, &ComicsModel::emitFetchingProgressChanged);
 
         m_list.append(comic);
     }
@@ -277,7 +277,7 @@ void ComicsModel::startAutomaticFetch(int interval)
 {
     m_automaticFetchTimer = new QTimer(this);
     m_automaticFetchTimer->start(interval);
-    connect(m_automaticFetchTimer, SIGNAL(timeout()), this, SLOT(fetchAll()));
+    connect(m_automaticFetchTimer, &QTimer::timeout, this, &ComicsModel::fetchAll);
 }
 
 int ComicsModel::count() const

--- a/src/ComicsModelProxy.cpp
+++ b/src/ComicsModelProxy.cpp
@@ -14,7 +14,7 @@ ComicsModelProxy::ComicsModelProxy(QObject *parent) :
 {
     setDynamicSortFilter(false);
 
-    connect(this, SIGNAL(sourceModelChanged()), this, SIGNAL(comicsModelChanged()));
+    connect(this, &ComicsModelProxy::sourceModelChanged, this, &ComicsModelProxy::comicsModelChanged);
 }
 
 bool ComicsModelProxy::filterAcceptsRow(int source_row, const QModelIndex &source_parent) const

--- a/src/FavoriteComicsModel.cpp
+++ b/src/FavoriteComicsModel.cpp
@@ -17,7 +17,7 @@
 FavoriteComicsModel::FavoriteComicsModel(QObject *parent) :
     ComicsModel(parent)
 {
-    connect(settings, SIGNAL(favoritesChanged()), this, SIGNAL(favoritesChanged()));
+    connect(settings, &Settings::favoritesChanged, this, &FavoriteComicsModel::favoritesChanged);
 }
 
 QStringList FavoriteComicsModel::idLoadList()


### PR DESCRIPTION
utilize the "new" qt5 signal-slot-connect statements, see also https://wiki.qt.io/New_Signal_Slot_Syntax

as this does compile time checks instead of runtime checks, it should not be as error-prone (with typos and such)