### PR TITLE
Repair swamp

### DIFF
--- a/plugins/swamp/extract.js
+++ b/plugins/swamp/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /<img[^>]*src='(strips\/[^']*)'/;
+    var regex = /<img[^>]+src="([^"]+)"[^>]+alt="Swamp\s+Cartoon\s+of\s+the\s+Day/;
     var match = regex.exec(page);
     return match[1];
 }


### PR DESCRIPTION
Unfortunately the URL has to be found using its alt description.

I tried it editing `/usr/share/harbour-dailycomics/plugins/swamp/extract.js` on my phone and it works.

Fixes #88