### PR TITLE
Fix spelling

### DIFF
--- a/plugins/spiegel/info.json
+++ b/plugins/spiegel/info.json
@@ -1,5 +1,5 @@
 {
-  "name": "spiegel",
+  "name": "SPIEGEL",
   "color": "e84416",
   "language": "de",
   "authors": [


### PR DESCRIPTION
Initially I did not comprehend that the JSON **name** is a free form field, hence does not need to correspond to the plugin directory name.
Thus correcting SPIEGEL's spelling to its regular one (all caps).