### PR TITLE
Add file type suffix to file name when saving to gallery

### DIFF
--- a/src/ComicStripFileResource.cpp
+++ b/src/ComicStripFileResource.cpp
@@ -11,6 +11,7 @@
 #include <QStandardPaths>
 #include <QDir>
 #include <QFile>
+#include <QMimeDatabase>
 
 #include "Comic.h"
 
@@ -70,8 +71,12 @@ bool ComicStripFileResource::saveToGallery(QString id)
     }
 
     QUrl stripPath = QUrl::fromLocalFile(path(id));
+    QMimeDatabase db;
+    QMimeType mime = db.mimeTypeForFile(stripPath.toLocalFile());
+    QString suffix = mime.preferredSuffix().isEmpty() ? "" : ("." + mime.preferredSuffix());
+
     return QFile::copy(stripPath.toLocalFile(), m_picturesDirPath + "/" + stripPath.fileName() +
-            "_" + QString::number(QDateTime::currentMSecsSinceEpoch()));
+            "_" + QString::number(QDateTime::currentMSecsSinceEpoch()) + suffix);
 }
 
 QString ComicStripFileResource::dirPath()


### PR DESCRIPTION
Currently, comic strips are saved without ".jpg", ".png", etc. suffixes. While file manager apps and the native gallery app don't care, the files do not show up in the Android gallery.

This patch uses Qt's built-in mime type features to add the correct suffix when saving to the gallery.